### PR TITLE
RingBuffer improve efficiency

### DIFF
--- a/Core/APU/Mechanics/DAC.cpp
+++ b/Core/APU/Mechanics/DAC.cpp
@@ -11,7 +11,7 @@ using namespace API;
 
 namespace Core
 {
-DAC::DAC() : _sample_buffer_per_terminal{API::RingBuffer<float_t>{1024 * 4}, API::RingBuffer<float_t>{1024 * 4}}
+DAC::DAC()
 {
 #if !defined(_DEBUG) || _DEBUG 0
     const auto wave_callback = [](const void* input, void* output, unsigned long frames,
@@ -56,7 +56,7 @@ void DAC::FeedSamples(const SampleData& samples)
     
     // Wait with the start of the DAC until we filled the buffer a bit
     if (!Pa_IsStreamActive(this->_stream) &&
-        this->_sample_buffer_per_terminal[static_cast<std::size_t>(OutputTerminal::SO1)].GetSize() >= API::BUFFER_FRAMES * 2)
+        this->_sample_buffer_per_terminal[static_cast<std::size_t>(OutputTerminal::SO1)].GetCapacity() >= API::BUFFER_FRAMES * 2)
     {
         SANITY(Pa_StartStream(this->_stream) == PaErrorCode::paNoError, "Failed starting stream");
     }

--- a/Core/APU/Mechanics/DAC.h
+++ b/Core/APU/Mechanics/DAC.h
@@ -38,8 +38,8 @@ private:
     void Populate(gsl::not_null<float*> buffer);
 
 private:
-	std::array<API::RingBuffer<float_t>, API::OUTPUT_TERMINALS_AMOUNT> _sample_buffer_per_terminal;
-	PaStream*														   _stream{nullptr};
+	std::array<API::RingBuffer<float_t, 1024 * 4>, API::OUTPUT_TERMINALS_AMOUNT> _sample_buffer_per_terminal{};
+	PaStream*														             _stream{nullptr};
 };
 } // Core
 


### PR DESCRIPTION
The RingBuffer behind the DAC is more efficient, since it holds both of it's channels in the cache, and reduces the need to jump to allocated memory by derefencing a unique_ptr buffer. Also, removed the use of mutex since this is a classic example of an atomic seq_cst int.